### PR TITLE
Run rustdoc on CI

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,0 +1,18 @@
+name: Rustdoc
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Doc
+      run: cargo doc --verbose


### PR DESCRIPTION
I had an issue where doc.rs failed to generate the documentation because of an error happening when the os is not Windows or MacOS so I'm adding this workflow to try to catch futur issues.